### PR TITLE
Form element default value fix.

### DIFF
--- a/src/Form/Element.php
+++ b/src/Form/Element.php
@@ -22,6 +22,11 @@ abstract class Element implements HtmlElement, Validable, Relationship
 
     protected $viewParams = [];
 
+    /**
+     * @var mixed
+     */
+    protected $defaultValue;
+
     public function __construct($name, array $attributes = [])
     {
         $this->setName($name);
@@ -85,7 +90,7 @@ abstract class Element implements HtmlElement, Validable, Relationship
     final public function html()
     {
         if (!$this->value) {
-            $this->setDefaultValue();
+            $this->populateValue();
         }
 
         if ($this->translatable) {
@@ -117,7 +122,18 @@ abstract class Element implements HtmlElement, Validable, Relationship
      */
     abstract public function render();
 
-    protected function setDefaultValue()
+    /**
+     * @param mixed $value
+     * @return $this
+     */
+    public function setDefaultValue($value)
+    {
+        $this->defaultValue = $value;
+
+        return $this;
+    }
+
+    protected function populateValue()
     {
         /**
          * If relation detected => try to extract value from relation or magnet link
@@ -159,6 +175,10 @@ abstract class Element implements HtmlElement, Validable, Relationship
          */
         if ($magnet = $this->isMagnetParameter()) {
             return $this->setValue($magnet[$this->getName()]);
+        }
+
+        if ($this->defaultValue) {
+            return $this->setValue($this->defaultValue);
         }
 
         return null;


### PR DESCRIPTION
Hello, sometimes, it is necessary to set default value for particular form element, but there is no such feature. I know, there are "magnet params" feature, but it slightly differs from "default value" one. Also I know, there was `setDefaultValue` protected method, I've just renamed it to `populateValue` one and implemented new `setDefaultValue` method. So, using this pull request, you can set default value for form element, just calling `setDefaultValue` in `MyModule::form()` method, like this:

```php
public function form()
{
        return $this
            ->scaffoldForm()
            ->update('number', function (FormElement $element) {
                return $element->setInput(
                    (new Number('number'))->setDefaultValue(date('Y'))
                );
            })
}
```