### PR TITLE
Replace the hardcoded \App\User::class name

### DIFF
--- a/src/Dashboard/Panels/MembersPanel.php
+++ b/src/Dashboard/Panels/MembersPanel.php
@@ -2,7 +2,6 @@
 
 namespace Terranet\Administrator\Dashboard\Panels;
 
-use App\User;
 use DB;
 use Terranet\Administrator\Dashboard\DashboardPanel;
 use Terranet\Administrator\Traits\Stringify;
@@ -41,6 +40,7 @@ class MembersPanel extends DashboardPanel
      */
     protected function createModel()
     {
-        return new User();
+        $userModelName = config('administrator.auth.model', '\App\User');
+        return new $userModelName();
     }
 }

--- a/src/Dashboard/Panels/MembersPanel.php
+++ b/src/Dashboard/Panels/MembersPanel.php
@@ -40,7 +40,8 @@ class MembersPanel extends DashboardPanel
      */
     protected function createModel()
     {
-        $userModelName = config('administrator.auth.model', '\App\User');
-        return new $userModelName();
+        $model = config('administrator.auth.model', '\App\User');
+        
+        return new $model();
     }
 }

--- a/src/Modules/Users.php
+++ b/src/Modules/Users.php
@@ -31,7 +31,8 @@ class Users extends Scaffolding implements Navigable, Filtrable, Editable, Valid
 
     public function model()
     {
-        $userModelName = config('administrator.auth.model', '\App\User');
-        return new $userModelName();
+        $model = config('administrator.auth.model', '\App\User');
+        
+        return new $model();
     }
 }

--- a/src/Modules/Users.php
+++ b/src/Modules/Users.php
@@ -2,7 +2,6 @@
 
 namespace Terranet\Administrator\Modules;
 
-use App\User;
 use Terranet\Administrator\Contracts\Module\Editable;
 use Terranet\Administrator\Contracts\Module\Exportable;
 use Terranet\Administrator\Contracts\Module\Filtrable;
@@ -20,8 +19,6 @@ class Users extends Scaffolding implements Navigable, Filtrable, Editable, Valid
 {
     use HasFilters, HasForm, HasSortable, ValidatesForm, AllowFormats;
 
-    protected $model = User::class;
-
     public function group()
     {
         return trans('administrator::module.groups.users');
@@ -30,5 +27,11 @@ class Users extends Scaffolding implements Navigable, Filtrable, Editable, Valid
     public function linkAttributes()
     {
         return ['icon' => 'fa fa-user'];
+    }
+
+    public function model()
+    {
+        $userModelName = config('administrator.auth.model', '\App\User');
+        return new $userModelName();
     }
 }


### PR DESCRIPTION
This fix allows you to store your User model in any location you want. It always
uses the path the the correct model from the config with a fallback to \App\User.