### PR TITLE
Use null coalesce operator in favour of deprecated or

### DIFF
--- a/publishes/views/components/index/index.blade.php
+++ b/publishes/views/components/index/index.blade.php
@@ -4,29 +4,29 @@
             <?php echo Form::hidden('batch_action', null, ['id' => 'batch_action']); ?>
             <?php echo Form::token(); ?>
 
-            {{ $gridBefore or '' }}
+            {{ $gridBefore ?? '' }}
 
             <table class="table table-bordered">
                 <thead>
                 <tr>
-                    {{ $checkboxes or '' }} {{ $headers or '' }} {{ $actions or '' }}
+                    {{ $checkboxes ?? '' }} {{ $headers ?? '' }} {{ $actions ?? '' }}
                 </tr>
                 </thead>
 
                 <tbody>
-                {{ $rows or '' }}
+                {{ $rows ?? '' }}
                 </tbody>
 
                 @if ($items && count($items) > 10)
                     <tfoot>
                     <tr>
-                        {{ $checkboxes or '' }} {{ $headers or '' }} {{ $actions or '' }}
+                        {{ $checkboxes ?? '' }} {{ $headers ?? '' }} {{ $actions ?? '' }}
                     </tr>
                     </tfoot>
                 @endif
             </table>
 
-            {{ $gridAfter or '' }}
+            {{ $gridAfter ?? '' }}
         </form>
 
         @if (trim($exportable ?? null) || trim($paginator ?? null))


### PR DESCRIPTION
As per https://laravel.com/docs/5.7/upgrade the blade {{ or }} operator is deprecated in favour of PHPs own ?? 'null coalesce operator'.

I've been running adminarchitec fine on laravel 5.7 so far. Apart from this one file where the or operator is used. The end result is all index pages showing only 1 1 1 1 instead of actual rows. 