### PR TITLE
Switch to HTTPS version of Google fonts API URL.

### DIFF
--- a/publishes/resources/sass/_quirk.scss
+++ b/publishes/resources/sass/_quirk.scss
@@ -5,7 +5,7 @@
  * Last compiled on Wednesday, July 22nd, 2015, 9:20:49 AM
  */
 
-@import url(http://fonts.googleapis.com/css?family=Roboto+Condensed:400,400italic,600,600italic,700,700italic,300italic,300);
+@import url(https://fonts.googleapis.com/css?family=Roboto+Condensed:400,400italic,600,600italic,700,700italic,300italic,300);
 /*!
  * Bootstrap v3.3.5 (http://getbootstrap.com)
  * Copyright 2011-2015 Twitter, Inc.


### PR DESCRIPTION
Hi, it's really best practice to use the HTTPS versions of the Google fonts API URLs, or any external API that has an https:// version available for that matter. As such I'm making this PR. Please consider merging it (F.Y.I I sent a similar PR on the 1.6 branch.)

P.S. Great work on this package!