### PR TITLE
Update AdminController.php

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -18,7 +18,7 @@ abstract class AdminController extends BaseController
      */
     protected $translator = null;
 
-    public function __construct(Translator $translator)
+    public function __construct(Translator $translator = null)
     {
         $this->middleware([
             AuthProvider::class,


### PR DESCRIPTION
After install L5.8 and install admin architect. When I run in console route:list Laravel returned error:
"
 Symfony\Component\Debug\Exception\FatalThrowableError  : Too few arguments to function Terranet\Administrator\Controllers\AdminController::__construct(), 0 passed in /var/www/umowy/vendor/adminarchitect/core/src/Controllers/TranslationsController.php on line 22 and exactly 1 expected

  at /var/www/umowy/vendor/adminarchitect/core/src/Controllers/AdminController.php:21
    17|      * @var \Illuminate\Translation\Translator|null
    18|      */
    19|     protected $translator = null;
    20|
  > 21|     public function __construct(Translator $translator)
    22|     {
    23|         $this->middleware([
    24|             AuthProvider::class,
    25|             Authenticate::class,

  Exception trace:

  1   Terranet\Administrator\Controllers\AdminController::__construct()
      /var/www/umowy/vendor/adminarchitect/core/src/Controllers/TranslationsController.php:22
"

I run code on php 7.1.29 on debian 9 and php 7.1.27 on windows 10.

Adding null to constructor parameter, resolved problem.