### PR TITLE
Prevent function calling by database value

### DIFF
--- a/src/Traits/Form/FormControl.php
+++ b/src/Traits/Form/FormControl.php
@@ -94,11 +94,14 @@ trait FormControl
      */
     public function setValue($value = null)
     {
-        if (is_callable($value)) {
+        if (is_callable($value) && !is_string($value)) {
             $value = call_user_func($value);
         }
 
-        $value = $this->handleJsonType($value);
+        // In tests, scaffold.model is not bound, and handleJsonType() raises error.
+        if (app()->bound('scaffold.model')) {
+            $value = $this->handleJsonType($value);
+        }
 
         $this->value = $value;
 

--- a/src/Traits/Form/FormControl.php
+++ b/src/Traits/Form/FormControl.php
@@ -94,7 +94,7 @@ trait FormControl
      */
     public function setValue($value = null)
     {
-        if (is_callable($value) && !is_string($value)) {
+        if ($value instanceof \Closure) {
             $value = call_user_func($value);
         }
 

--- a/tests/Form/FormElementTest.php
+++ b/tests/Form/FormElementTest.php
@@ -111,8 +111,13 @@ class FormElementTest extends \PHPUnit\Framework\TestCase
     public function it_prevents_function_calling_by_database_value()
     {
         $text = FormElement::text('text');
-        $text->setValue('time');
 
+        $text->setValue('time');
         $this->assertSame('time', $text->getInput()->getValue());
+
+        $text->setValue(function () {
+            return 42;
+        });
+        $this->assertSame(42, $text->getInput()->getValue());
     }
 }

--- a/tests/Form/FormElementTest.php
+++ b/tests/Form/FormElementTest.php
@@ -106,4 +106,13 @@ class FormElementTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('data-type', $attributes = $search->getInput()->getAttributes());
         $this->assertSame('livesearch', $attributes['data-type']);
     }
+
+    /** @test */
+    public function it_prevents_function_calling_by_database_value()
+    {
+        $text = FormElement::text('text');
+        $text->setValue('time');
+
+        $this->assertSame('time', $text->getInput()->getValue());
+    }
 }


### PR DESCRIPTION
When callable string (e.g. PHP built-in function names, Laravel helper function names, etc) in database, and that string shows in edit form (like /cms/users/1/edit), that string called as function unintentionally.

This behavior may be slightly vulnerable.

PR fixes this behavior, but I don't know if this method is appropriate.

Related #46
