### PR TITLE
fix v10 fresh install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-dom": "*",
         "laravelcollective/html": "^5.0|^6.0|^7.0|dev-master",
         "doctrine/dbal": "^3.6",
-        "doctrine/annotations": "^1.6",
+        "doctrine/annotations": "^2.0",
         "terranet/menus": "^2.2",
         "terranet/presentable": "^1.0",
         "terranet/translatable": "^1.2",

--- a/publishes/routes.php
+++ b/publishes/routes.php
@@ -74,7 +74,7 @@ Route::post('{module}/{id}/media/{collection}', [
 
 // Upload media attachment
 Route::delete('{module}/{id}/media/{mediaId}', [
-    'as' => 'scaffold.attach_media',
+    'as' => 'scaffold.detach_media',
     'uses' => 'ScaffoldController@detachMedia',
 ])->where('module', $pattern);
 

--- a/src/Dashboard/Panels/DatabasePanel.php
+++ b/src/Dashboard/Panels/DatabasePanel.php
@@ -26,7 +26,8 @@ class DatabasePanel extends Panel
     protected function getDatabaseStats()
     {
         if (connection('mysql')) {
-            return $this->connection()->select($this->connection()->raw('SHOW TABLE STATUS'));
+            $query = $this->connection()->raw('SHOW TABLE STATUS')->getValue($this->connection()->getQueryGrammar());
+            return $this->connection()->select($query);
         }
 
         return collect([]);

--- a/src/Providers/ContainersServiceProvider.php
+++ b/src/Providers/ContainersServiceProvider.php
@@ -2,8 +2,7 @@
 
 namespace Terranet\Administrator\Providers;
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Annotations\SimpleAnnotationReader;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
@@ -36,12 +35,7 @@ class ContainersServiceProvider extends ServiceProvider
     protected function registerAdminAnnotations()
     {
         $this->app->singleton('scaffold.annotations', function () {
-            AnnotationRegistry::registerUniqueLoader('class_exists');
-
-            $reader = new SimpleAnnotationReader();
-            $reader->addNamespace('\\Terranet\\Administrator\\Annotations');
-
-            return $reader;
+            return new AnnotationReader();
         });
     }
 


### PR DESCRIPTION
Laravel 10 fresh install requires doctrine annotation ^2.0 so installation fails. Updated annotations versions. Tested ScopeFilter annotation - works well.
Should fix #92 

Also there is issue with raw queries in v10, here is [upgrade guide](https://laravel.com/docs/10.x/upgrade#database-expressions). Fixed as well
